### PR TITLE
[ADDED] #175577, [UPDATED] #180398, [UPDATED] #170789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ El formato está basado en [SemVer](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- #175577: Añadidos campos de fecha de inicio y final al email de bienvenida del curso.
 - #198292: Añadida la posibilidad de ordenar las ediciones de un curso
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ El formato está basado en [SemVer](https://semver.org/spec/v2.0.0.html).
 
 - #198251: tipos de cursos, se tienen en cuenta los inactivos, se modifica para establecer el tipo de tipo de curso en la creación y en la edición.
 - #180398: Ahora los métodos de evaluación aparecen en orden alfabético en el desplegable, sin importar el idioma seleccionado.
+- #170789: Ahora en el apartado de correcciones de actividades de un curso aparecen solo los alumnos, aunque se realicen búsquedas.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ El formato está basado en [SemVer](https://semver.org/spec/v2.0.0.html).
 ### Updated
 
 - #198251: tipos de cursos, se tienen en cuenta los inactivos, se modifica para establecer el tipo de tipo de curso en la creación y en la edición.
+- #180398: Ahora los métodos de evaluación aparecen en orden alfabético en el desplegable, sin importar el idioma seleccionado.
 
 ### Fixed
 

--- a/docroot/html/courseadmin/editcourse.jsp
+++ b/docroot/html/courseadmin/editcourse.jsp
@@ -1,3 +1,4 @@
+<%@page import="java.util.TreeMap"%>
 <%@page import="com.liferay.portal.kernel.util.DateUtil"%>
 <%@page import="com.liferay.lms.service.CourseTypeLocalServiceUtil"%>
 <%@page import="com.liferay.lms.course.inscriptiontype.InscriptionType"%>
@@ -664,7 +665,14 @@ if(isCourseChild){
 		}
 		CourseEvalRegistry cer=new CourseEvalRegistry();
 		CourseEval courseEval = null;
-		if(courseEvalIds.size()>1){%>
+		if(courseEvalIds.size()>1){
+		Map<String, Long> mapCourseEvalType = new TreeMap<String, Long>();
+		for(Long ce:courseEvalIds)
+		{
+			CourseEval cel = cer.getCourseEval(ce);
+			mapCourseEvalType.put(cel.getName(locale),ce);
+		}
+		courseEvalIds = new ArrayList(mapCourseEvalType.values());%>
 			<aui:select name="courseEvalId" label="course-correction-method" helpMessage="<%=LanguageUtil.get(pageContext,\"course-correction-method-help\")%>" 
 						onChange="<%=\"javascript:\"+renderResponse.getNamespace()+\"changeEvaluationMethod(this.value);AUI().use('aui-io-request','aui-parse-content','querystring',function(A){ \"+
 								\"	var courseCombo = document.getElementById('\"+renderResponse.getNamespace()+\"courseEvalId'), \"+

--- a/docroot/html/courseadmin/editcourse.jsp
+++ b/docroot/html/courseadmin/editcourse.jsp
@@ -1,3 +1,4 @@
+<%@page import="com.liferay.portal.kernel.util.DateUtil"%>
 <%@page import="com.liferay.lms.service.CourseTypeLocalServiceUtil"%>
 <%@page import="com.liferay.lms.course.inscriptiontype.InscriptionType"%>
 <%@page import="com.liferay.lms.course.inscriptiontype.InscriptionTypeRegistry"%>
@@ -1165,6 +1166,18 @@ if(isCourseChild){
 							</dt>
 							<dd>
 								<liferay-ui:message key="course-admin.welcome-message.user" />
+							</dd>
+							<dt>
+								[$START_DATE$]
+							</dt>
+							<dd>
+								<%= (course!=null?course.getExecutionStartDate():DateUtil.ISO_8601_PATTERN)  %>
+							</dd>
+							<dt>
+								[$END_DATE$]
+							</dt>
+							<dd>
+								<%= (course!=null?course.getExecutionEndDate():DateUtil.ISO_8601_PATTERN)  %>
 							</dd>
 						</dl>
 					</div>

--- a/docroot/html/execactivity/test/correction.jsp
+++ b/docroot/html/execactivity/test/correction.jsp
@@ -203,6 +203,8 @@ userSearchContainer.setTotal(totalUsers);
 		</div>
 	</aui:form>
 
+<p hidden><%= userSearchContainer.getResults().retainAll(CourseLocalServiceUtil.getStudentsFromCourse(course)) %></p>
+
 	<liferay-ui:search-container 
 		searchContainer="<%=userSearchContainer %>" 
 		iteratorURL="<%=userSearchContainer.getIteratorURL() %>"
@@ -210,7 +212,7 @@ userSearchContainer.setTotal(totalUsers);
 		>
 					
 				<liferay-ui:search-container-results 
-					total="<%=userSearchContainer.getTotal() %>" 
+					total="<%=userSearchContainer.getResults().size() %>" 
 					results="<%=userSearchContainer.getResults() %>"
 				/>
 


### PR DESCRIPTION
Se han añadido los campos de fecha de inicio y final al email de bienvenida del curso, como se pedía en el ticket #175577.
Ahora los métodos de evaluación aparecen en orden alfabético en el desplegable, sin importar el idioma seleccionado #180398.
Ahora en el apartado de correcciones de actividades de un curso aparecen solo los alumnos, aunque se realicen búsquedas #170789.

Se ha registrado los cambios en el CHANGELOG.md.