### PR TITLE
[UPDATED] #177715 Evitar que se modifique el estado de publicacion en catalogo al cerrar y reabrir un curso

### DIFF
--- a/docroot/WEB-INF/src/com/liferay/lms/service/impl/CourseLocalServiceImpl.java
+++ b/docroot/WEB-INF/src/com/liferay/lms/service/impl/CourseLocalServiceImpl.java
@@ -831,9 +831,9 @@ public class CourseLocalServiceImpl extends CourseLocalServiceBaseImpl {
 			courseGroup.setActive(false);
 			GroupLocalServiceUtil.updateGroup(courseGroup);
 			course = coursePersistence.update(course, true);		
-			AssetEntry courseAsset=AssetEntryLocalServiceUtil.getEntry(Course.class.getName(), course.getCourseId());
-			courseAsset.setVisible(false);
-			AssetEntryLocalServiceUtil.updateAssetEntry(courseAsset);
+//			AssetEntry courseAsset=AssetEntryLocalServiceUtil.getEntry(Course.class.getName(), course.getCourseId());
+//			courseAsset.setVisible(false);
+//			AssetEntryLocalServiceUtil.updateAssetEntry(courseAsset);
 
 			CourseEval courseEval=new CourseEvalRegistry().getCourseEval(course.getCourseEvalId());
 			if(Validator.isNotNull(courseEval)) {
@@ -862,9 +862,9 @@ public class CourseLocalServiceImpl extends CourseLocalServiceBaseImpl {
 			courseGroup.setActive(true);
 			groupLocalService.updateGroup(courseGroup);
 			course = coursePersistence.update(course, true);	
-			AssetEntry courseAsset=assetEntryLocalService.getEntry(Course.class.getName(), course.getCourseId());
-			courseAsset.setVisible(true);
-			assetEntryLocalService.updateAssetEntry(courseAsset);
+//			AssetEntry courseAsset=assetEntryLocalService.getEntry(Course.class.getName(), course.getCourseId());
+//			courseAsset.setVisible(true);
+//			assetEntryLocalService.updateAssetEntry(courseAsset);
 
 			CourseEval courseEval=new CourseEvalRegistry().getCourseEval(course.getCourseEvalId());
 			if(Validator.isNotNull(courseEval)) {


### PR DESCRIPTION
### Incidencia #177715 - Cuando cierras un curso y después se reabre, lo pone como publicado en catálogo

Se ha modificado `CourseLocalServiceImpl.java` para que no se modifique el estado de publicación en el catálogo al cerrar y reabrir un curso (el atributo de visibilidad como `AssetEntry`), ya que **solo se mostrarán en el catálogo aquellos cursos que no estén cerrados y estén visibles**.

Marcar el checkbox en la edición del curso sí que cambia la visibilidad del `AssetEntry` (sin cambios).