### PR TITLE
[UPDATED] #191847 La fecha de entrega de una actividad de desarrollo se actualiza con la del último intento.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ El formato está basado en [SemVer](https://semver.org/spec/v2.0.0.html).
 ### Updated
 
 - #198251: tipos de cursos, se tienen en cuenta los inactivos, se modifica para establecer el tipo de tipo de curso en la creación y en la edición.
+- #191847: La fecha de entrega de una actividad de desarrollo se actualiza con la del último intento.
 
 ### Fixed
 

--- a/docroot/WEB-INF/src/com/liferay/lms/OnlineActivity.java
+++ b/docroot/WEB-INF/src/com/liferay/lms/OnlineActivity.java
@@ -333,6 +333,7 @@ public class OnlineActivity extends MVCPortlet {
 			if(Validator.isNotNull(result) && Validator.isNull(result.getEndDate())){
 				//Si hay resultado sin corregir se actualiza el último try
 				learningActivityTry = LearningActivityTryLocalServiceUtil.getLastLearningActivityTryByActivityAndUser(actId, user.getUserId());
+				learningActivityTry.setStartDate(new Date());
 				//Si no se ha subido un archivo nuevo vuelvo a guardar el archivo que estaba guardado previamente
 				if(isSetFichero && Validator.isNull(fileName)){
 					Iterator<Node> nodeItr = SAXReaderUtil.read(learningActivityTry.getTryResultData()).getRootElement().nodeIterator();	


### PR DESCRIPTION
#191847 La fecha de entrega de una actividad de desarrollo se actualiza con la del último intento.