### PR TITLE
[FIXED] #236823 - Permitir contestar encuestas

### DIFF
--- a/docroot/WEB-INF/service/com/tls/lms/util/LiferaylmsUtil.java
+++ b/docroot/WEB-INF/service/com/tls/lms/util/LiferaylmsUtil.java
@@ -346,7 +346,7 @@ public class LiferaylmsUtil {
 	public static boolean hasPermissionAccessQualitySurveyCoursesExecution(Course course){
 		Date now = new Date();
 		try {
-			return (course.getExecutionStartDate() == null || course.getExecutionStartDate().before(now)) && (course.getExecutionEndDate() == null || course.getExecutionEndDate().after(now)) && PrefsPropsUtil.getBoolean(course.getCompanyId(), LmsConstant.PREFS_ACCESS_QUALITY_SURVEY_EXECUTION_DATES, false);
+			return (course.getExecutionStartDate() == null || course.getExecutionStartDate().before(now)) && (course.getExecutionEndDate() == null || course.getExecutionEndDate().before(now)) && PrefsPropsUtil.getBoolean(course.getCompanyId(), LmsConstant.PREFS_ACCESS_QUALITY_SURVEY_EXECUTION_DATES, false);
 		} catch (SystemException e) {
 			e.printStackTrace();
 			return false;


### PR DESCRIPTION
[FIXED] #236823 - Permitir contestar encuestas cuando se haya superado las fechas de ejecución del curso y esté marcado el check de la configuracion LMS "Permite el a la encuestas de calidad que estén después de la fecha de ejecución del curso"